### PR TITLE
feat(boosty): add Boosty publisher with tier-based paywall

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,17 @@ WP_PASSWORD = "password"
 WP_APP_PASSWORD = "app_password"
 
 
+# BOOSTY
+# Slug блога: boosty.to/<BOOSTY_BLOG>
+BOOSTY_BLOG = "my_blog"
+# auth.json экспортируется один раз из браузерной сессии (access_token /
+# refresh_token / device_id). Путь внутри контейнера (volume boosty_data).
+BOOSTY_AUTH_FILE = "/app/data/boosty_auth.json"
+# Имя ИЛИ числовой id уровня подписки. paywall_tier в событии переопределяет.
+BOOSTY_AFTERSHOW_LEVEL = "Подписка"   # платный уровень для aftershow
+BOOSTY_FREE_LEVEL = "Бесплатный"      # бесплатный уровень для основных эпизодов
+
+
 # LOGGER SETTINGS
 # "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"
 LOG_LEVEL = "INFO"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,23 @@ jobs:
         run: python -m pip install "pytest>=8.3.2,<9" "pytest-asyncio>=0.24,<0.25"
       - name: Run WordPress publisher tests
         run: pytest -c app/bot/pyproject.toml -o addopts="" tests/unit/publishers/wordpress
+
+  test-publisher-boosty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Poetry
+        run: python -m pip install --upgrade pip poetry
+      - name: Install Boosty publisher dependencies (system env, mirrors Dockerfile)
+        working-directory: app/publishers/Boosty
+        run: |
+          poetry config virtualenvs.create false
+          poetry lock
+          poetry install --only main --no-root
+      - name: Install test tooling
+        run: python -m pip install "pytest>=8.3.2,<9" "pytest-asyncio>=0.24,<0.25"
+      - name: Run Boosty publisher tests
+        run: pytest -c app/bot/pyproject.toml -o addopts="" tests/unit/publishers/boosty

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ database.sqlite
 files/*.mp3
 files/*.pkl
 files/*.json
+boosty_auth.json
+**/boosty_auth.json
 anon.session
 tests/e2e/*.session
 tests/e2e/*.session-journal

--- a/app/kafka/topics.yaml
+++ b/app/kafka/topics.yaml
@@ -17,3 +17,12 @@ topics:
   - name: publisher.wordpress.result
     partitions: 1
     replication_factor: 1
+  - name: publisher.boosty.upload
+    partitions: 1
+    replication_factor: 1
+    config:
+      cleanup.policy: delete
+      retention.ms: 604800000  # 7 дней
+  - name: publisher.boosty.result
+    partitions: 1
+    replication_factor: 1

--- a/app/publishers/Boosty/Dockerfile
+++ b/app/publishers/Boosty/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Базовый образ для установки зависимостей
+FROM python:3.12-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates curl locales && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Устанавливаем локаль ru_RU.UTF-8
+RUN sed -i 's/# ru_RU.UTF-8 UTF-8/ru_RU.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    echo "LANG=ru_RU.UTF-8" > /etc/default/locale
+ENV LANG=ru_RU.UTF-8
+ENV LC_ALL=ru_RU.UTF-8
+
+RUN python -m pip install --upgrade pip && \
+    python -m pip install --upgrade poetry
+
+COPY app/publishers/Boosty/pyproject.toml /app/
+RUN poetry config virtualenvs.create false && \
+    poetry lock && \
+    poetry install --only main --no-root
+
+COPY app/shared /app/shared/
+COPY app/publishers/Boosty /app/
+
+FROM base AS final
+CMD ["python", "main.py"]

--- a/app/publishers/Boosty/boosty_client.py
+++ b/app/publishers/Boosty/boosty_client.py
@@ -1,0 +1,159 @@
+"""Тонкая обёртка над `barsikus007/boosty` для постинга с tier-привязкой.
+
+Почему не «голый» `API.create_post`: его модель `NewPost` НЕ сериализует
+`subscription_level_id`, а именно это поле привязывает пост к уровню
+подписки (см. спайк `.planning/spikes/boosty-sponsr-feasibility.md`,
+секция Paywall/tiers). Поэтому create-post шлём **сырым form-payload**
+через переиспользуемый `API.request(...)` — он сам подставляет
+`Authorization`-заголовок и обновляет токен по 401 (refresh_token +
+device_id из auth.json).
+
+Auth-bootstrap: один раз вручную логинимся в браузере, экспортируем
+`auth.json` (access_token / refresh_token / device_id / expires_at /
+user_agent) в `BOOSTY_AUTH_FILE`. `FileAuthDataResolver` читает/перезаписывает
+этот файл; refresh — внутри либы.
+
+Известный риск: `API.request` шлёт только базовые заголовки (UA +
+Authorization), без `X-App/X-Currency/X-Locale`. Собственный create_post
+либы работает так же, поэтому считаем достаточным; если internal-API
+начнёт требовать X-*, добавляем свой aiohttp-вызов (см. спайк, п. 4б).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from content import build_post_data
+from loguru import logger
+
+# Импорт либы изолирован: при отсутствии пакета (например, в unit-окружении
+# без установленного boosty) модуль всё равно импортируется, а понятная
+# ошибка всплывёт только при реальном построении клиента.
+try:
+    from boosty.api import API
+    from boosty.api.auth import Auth
+    from boosty.api.auth.resolvers.file import FileAuthDataResolver
+
+    _IMPORT_ERROR: Exception | None = None
+except Exception as e:  # pragma: no cover - зависит от окружения
+    API = Auth = FileAuthDataResolver = None  # type: ignore[assignment]
+    _IMPORT_ERROR = e
+
+
+class BoostyClient:
+    """Stateful-обёртка: один блог, ленивое построение API + кэш уровней."""
+
+    def __init__(self, blog_name: str, auth_file: str) -> None:
+        # Пустой blog_name допустим при конструировании (импорт модуля при
+        # незаданном BOOSTY_BLOG не должен падать); проверяем в ensure_auth.
+        self.blog_name = blog_name
+        self.auth_file = auth_file
+        self._api: API | None = None  # type: ignore[valid-type]
+        self._levels: dict[str, str] | None = None  # name(lower) -> id
+
+    # --- auth ---
+
+    async def ensure_auth(self) -> None:
+        """Строит API из auth.json (blocking IO → to_thread) и валидирует токен.
+
+        Идемпотентно: повторные вызовы — no-op. Сам refresh по 401 делает
+        `API.request`; здесь только начальная загрузка + понятная ошибка,
+        если файл с токеном не подготовлен.
+        """
+        if self._api is not None:
+            return
+        if not self.blog_name:
+            raise RuntimeError("BOOSTY_BLOG is not configured")
+        if _IMPORT_ERROR is not None:
+            raise RuntimeError(f"boosty library is not available: {_IMPORT_ERROR!r}")
+
+        def _build() -> API:  # type: ignore[valid-type]
+            auth = Auth(FileAuthDataResolver(self.auth_file))
+            return API(auth=auth)
+
+        api = await asyncio.to_thread(_build)
+        if not getattr(api.auth.auth_data, "access_token", None):
+            raise RuntimeError(
+                f"No access_token in {self.auth_file}. Export auth.json from a "
+                "browser session (access_token/refresh_token/device_id)."
+            )
+        self._api = api
+        logger.debug(f"Boosty auth loaded for blog '{self.blog_name}'")
+
+    # --- subscription levels ---
+
+    async def resolve_level_id(self, tier: str) -> str:
+        """Преобразует tier (имя уровня или сырой id) в `subscription_level_id`.
+
+        Числовая строка трактуется как готовый id. Иначе ищем уровень по
+        имени (case-insensitive) среди уровней блога.
+        """
+        tier = (tier or "").strip()
+        if not tier:
+            raise ValueError("Empty tier — cannot resolve subscription_level_id")
+        if tier.isdigit():
+            return tier
+
+        levels = await self._get_levels()
+        level_id = levels.get(tier.lower())
+        if level_id is None:
+            raise ValueError(
+                f"Subscription level '{tier}' not found for blog '{self.blog_name}'. Available: {sorted(levels)}"
+            )
+        return level_id
+
+    async def _get_levels(self) -> dict[str, str]:
+        if self._levels is not None:
+            return self._levels
+        await self.ensure_auth()
+        assert self._api is not None
+        resp = await self._api.request(
+            "GET",
+            f"/v1/blog/{self.blog_name}/subscription_level/",
+            params={"show_deleted": "false", "show_free_level": "true"},
+        )
+        items = resp.get("data", resp) if isinstance(resp, dict) else resp
+        levels: dict[str, str] = {}
+        for item in items or []:
+            name = item.get("name")
+            level_id = item.get("id")
+            if name is not None and level_id is not None:
+                levels[str(name).strip().lower()] = str(level_id)
+        self._levels = levels
+        logger.debug(f"Resolved Boosty levels: {levels}")
+        return levels
+
+    # --- posting ---
+
+    async def create_post(
+        self,
+        *,
+        title: str,
+        body: str,
+        subscription_level_id: str,
+        chapters: list[list[str]] | None = None,
+        tags: str = "",
+        price: str = "0",
+    ) -> str:
+        """Создаёт пост сырым form-payload. Возвращает id созданного поста."""
+        await self.ensure_auth()
+        assert self._api is not None
+
+        payload = {
+            "title": title,
+            "data": build_post_data(body, chapters),
+            "subscription_level_id": str(subscription_level_id),
+            "price": price,
+            "teaser_data": "[]",
+            "tags": tags,
+            "deny_comments": "false",
+            "wait_video": "false",
+            "has_chat": "false",
+            "advertiser_info": "",  # обязательное поле; пустое допустимо
+        }
+        resp = await self._api.request("POST", f"/v1/blog/{self.blog_name}/post/", data=payload)
+        post_id = ""
+        if isinstance(resp, dict):
+            post_id = str(resp.get("id") or resp.get("data", {}).get("id", ""))
+        logger.success(f"Boosty post created (id={post_id or '?'})")
+        return post_id

--- a/app/publishers/Boosty/content.py
+++ b/app/publishers/Boosty/content.py
@@ -1,0 +1,67 @@
+"""Сборка draft.js-контента для Boosty create-post.
+
+Boosty хранит тело поста как массив контент-блоков. Текстовый блок —
+`{"type":"text","content":"<json>","modificator":""}`, где `content` —
+**сама по себе JSON-строка** вида `["<raw text>", "unstyled", []]`
+(draft.js-подобная сериализация). Конец логического блока помечается
+отдельным блоком `{"type":"text","content":"","modificator":"BLOCK_END"}`.
+
+Либа `barsikus007/boosty` даёт только парсер (`render_text`), билдера нет —
+поэтому формат воспроизводим вручную. Подтверждено реверсом
+`HOCKI1/py_boosty_api` (см. спайк `.planning/spikes/boosty-sponsr-feasibility.md`).
+
+Модуль намеренно НЕ импортирует `boosty` — чистые функции, тестируются
+без установленной либы.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _text_block(text: str) -> dict[str, str]:
+    """Один draft.js текстовый блок. Внутренний слой — отдельный json.dumps."""
+    inner = json.dumps([text, "unstyled", []], ensure_ascii=False)
+    return {"type": "text", "content": inner, "modificator": ""}
+
+
+def _block_end() -> dict[str, str]:
+    """Маркер конца логического блока."""
+    return {"type": "text", "content": "", "modificator": "BLOCK_END"}
+
+
+def build_post_data(
+    body: str,
+    chapters: list[list[str]] | None = None,
+) -> str:
+    """Собирает значение поля `data` для create-post (внешний json.dumps).
+
+    Параграфы (`body`, разбитый по `\\n`) и таймлайн глав идут отдельными
+    текстовыми блоками; каждый абзац закрывается BLOCK_END. Пустые строки
+    пропускаются. Результат — JSON-строка, готовая лечь в form-поле `data`.
+    """
+    blocks: list[dict[str, str]] = []
+
+    paragraphs = [line for line in (body or "").split("\n") if line.strip()]
+    for para in paragraphs:
+        blocks.append(_text_block(para))
+        blocks.append(_block_end())
+
+    if chapters:
+        # Таймлайн отдельными строками "MM:SS — Название".
+        for chapter in chapters:
+            if not chapter:
+                continue
+            if len(chapter) >= 2:
+                line = f"{chapter[0]} — {chapter[1]}"
+            else:
+                line = str(chapter[0])
+            blocks.append(_text_block(line))
+            blocks.append(_block_end())
+
+    if not blocks:
+        # Boosty не принимает пустой пост; даём пустой текстовый блок.
+        blocks.append(_text_block(""))
+        blocks.append(_block_end())
+
+    return json.dumps(blocks, ensure_ascii=False)

--- a/app/publishers/Boosty/main.py
+++ b/app/publishers/Boosty/main.py
@@ -1,0 +1,116 @@
+"""Boosty publisher: подписан на publisher.boosty.upload, создаёт пост на
+Boosty через internal-API с привязкой к уровню подписки (paywall/tier),
+шлёт result в publisher.boosty.result.
+
+Tier-логика (см. BasePublisher.is_paywalled + спайк):
+* `paywall_tier` на событии (имя уровня или id) — высший приоритет;
+* иначе aftershow → платный уровень `BOOSTY_AFTERSHOW_LEVEL`,
+  main/прочее → бесплатный уровень `BOOSTY_FREE_LEVEL`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from boosty_client import BoostyClient
+from loguru import logger
+
+from shared.config import config
+from shared.kafka.models.boosty_event import BoostyEvent
+from shared.kafka.producer import KafkaProducer
+from shared.publishers.base import BasePublisher
+
+# Boosty-config — берётся только тут, base про эти переменные не знает.
+BOOSTY_BLOG = config.BOOSTY_BLOG
+BOOSTY_AUTH_FILE = config.BOOSTY_AUTH_FILE
+BOOSTY_AFTERSHOW_LEVEL = config.BOOSTY_AFTERSHOW_LEVEL
+BOOSTY_FREE_LEVEL = config.BOOSTY_FREE_LEVEL
+
+
+class BoostyPublisher(BasePublisher):
+    name = "boosty"
+    event_cls = BoostyEvent
+    schema_path = "/app/shared/kafka/schemas/boosty_event.avsc"
+    upload_topic = config.BOOSTY_UPLOAD_TOPIC
+    result_topic = config.BOOSTY_RESULT_TOPIC
+    group_id = "boosty_group"
+
+    supports_paywall = True
+    supports_scheduled = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.client = BoostyClient(BOOSTY_BLOG or "", BOOSTY_AUTH_FILE)
+
+    async def _ensure_auth(self) -> None:  # type: ignore[override]
+        await self.client.ensure_auth()
+
+    def _target_level(self, event: BoostyEvent) -> str:
+        """Имя/id уровня подписки для события.
+
+        paywall_tier приоритетен; иначе — дефолт по платности (is_paywalled).
+        """
+        if event.paywall_tier:
+            return event.paywall_tier
+        if self.is_paywalled(event):
+            if not BOOSTY_AFTERSHOW_LEVEL:
+                raise RuntimeError("Paid episode but BOOSTY_AFTERSHOW_LEVEL is not configured")
+            return BOOSTY_AFTERSHOW_LEVEL
+        if not BOOSTY_FREE_LEVEL:
+            raise RuntimeError("Public episode but BOOSTY_FREE_LEVEL is not configured")
+        return BOOSTY_FREE_LEVEL
+
+    async def publish(self, event: BoostyEvent) -> None:  # type: ignore[override]
+        level_id = await self.client.resolve_level_id(self._target_level(event))
+
+        post_id = await self.client.create_post(
+            title=event.title,
+            body=event.comment,
+            subscription_level_id=level_id,
+            chapters=event.chapters,
+            tags=",".join(event.tags),
+        )
+
+        result = event.model_copy(
+            update={
+                "event_type": "result",
+                "status": "success",
+                "post_id": post_id,
+            }
+        )
+        await self.producer.send(self.result_topic, result.model_dump())
+        logger.success(
+            f"Boosty upload completed for episode {event.number} (level={level_id}, post_id={post_id or '?'})"
+        )
+
+    def event_key(self, event: BoostyEvent) -> str:  # type: ignore[override]
+        return event.number
+
+    def build_failure_event(self, event: BoostyEvent, error: str):  # type: ignore[override]
+        return event.model_copy(
+            update={
+                "event_type": "result",
+                "status": "failure",
+                "error": error,
+            }
+        )
+
+
+_publisher = BoostyPublisher()
+
+
+async def handle_upload(payload: dict, producer: KafkaProducer | None = None) -> None:
+    """Test-compat shim. См. подробности в FTP/main.py.handle_upload."""
+    if producer is not None:
+        original = _publisher.producer
+        _publisher.producer = producer
+        try:
+            await _publisher._handle(payload)
+        finally:
+            _publisher.producer = original
+    else:
+        await _publisher._handle(payload)
+
+
+if __name__ == "__main__":
+    asyncio.run(_publisher.run())

--- a/app/publishers/Boosty/pyproject.toml
+++ b/app/publishers/Boosty/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.poetry]
+name = "publisher_boosty"
+version = "0.1.0"
+description = "Boosty publisher microservice"
+authors = ["k0te1ch <khvostov40@gmail.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+python-dotenv = "^1.2.2"
+loguru = "^0.7.3"
+prometheus-client = "^0.21.1"
+aioprometheus = "^23.12.0"
+aiohttp = "^3.13.3"
+fastavro = "^1.12.1"
+confluent-kafka = {extras = ["avro"], version = "^2.12.0"}
+pydantic = "^2.12.3"
+pydantic-settings = "^2.9.1"
+# Pin строго: internal-API Boosty нестабилен, либа hobby-grade
+# (см. .planning/spikes/boosty-sponsr-feasibility.md → Stability risk).
+boosty = "0.0.35"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/app/shared/config/config.py
+++ b/app/shared/config/config.py
@@ -60,6 +60,14 @@ class SharedSettings(BaseSettings):
     WP_RESULT_TOPIC: str = "publisher.wordpress.result"
     WP_COOKIE_PATH: str = "/app/data/cookie.pkl"
 
+    # Boosty
+    BOOSTY_BLOG: str | None = None  # slug блога (boosty.to/<slug>)
+    BOOSTY_AUTH_FILE: str = "/app/data/boosty_auth.json"  # экспорт токенов из браузера
+    BOOSTY_AFTERSHOW_LEVEL: str | None = None  # имя или id платного уровня (paywall)
+    BOOSTY_FREE_LEVEL: str | None = None  # имя или id бесплатного уровня (public)
+    BOOSTY_UPLOAD_TOPIC: str = "publisher.boosty.upload"
+    BOOSTY_RESULT_TOPIC: str = "publisher.boosty.result"
+
     # Metrics
     PUSHGATEWAY_URL: str = "http://localhost:9091"
 

--- a/app/shared/kafka/models/boosty_event.py
+++ b/app/shared/kafka/models/boosty_event.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel, Field, field_validator
+
+
+class BoostyEvent(BaseModel):
+    """Событие публикации поста на Boosty.
+
+    Мирроринг WordPressEvent: своя модель + .avsc + топик. Несёт всё, что
+    нужно для создания поста через internal-API Boosty (см. спайк
+    `.planning/spikes/boosty-sponsr-feasibility.md`):
+
+    * `title`/`comment` — заголовок и тело поста;
+    * `type_episode`/`paywall_tier` — определяют tier (free vs paid level),
+      см. `BasePublisher.is_paywalled`;
+    * `post_id` — id созданного поста (заполняется в success-result для
+      идемпотентности/дедупа на стороне бота).
+    """
+
+    event_type: str = Field(..., description="Тип события: request | result")
+    username: str = Field(..., min_length=1)
+    status: str | None = Field(None, description="pending | success | failure")
+    error: str | None = Field(None, description="Описание ошибки")
+    chat_id: str | None = Field(None)
+    message_id: str | None = Field(None)
+
+    # Данные поста
+    number: str = Field(..., description="Номер эпизода")
+    title: str = Field(...)
+    comment: str = Field(..., description="Тело поста / описание эпизода")
+    chapters: list[list[str]] = Field(default_factory=list, description="Таймлайн [[time, name], ...]")
+    tags: list[str] = Field(default_factory=list)
+
+    # Paywall / tier
+    type_episode: str | None = Field(
+        None, description="main | aftershow — определяет paywall для платных publisher'ов"
+    )
+    paywall_tier: str | None = Field(
+        None,
+        description=(
+            "Явный tier: имя уровня подписки Boosty или его id. Приоритетнее "
+            "type_episode. None → используется дефолтный уровень из конфига "
+            "(aftershow → платный, иначе → бесплатный)."
+        ),
+    )
+
+    # Заполняется в success-result
+    post_id: str | None = Field(None, description="ID созданного поста на Boosty")
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v):
+        if v is None:
+            return v
+        allowed = {"pending", "success", "failure"}
+        if v not in allowed:
+            raise ValueError(f"Invalid status '{v}', must be one of {allowed}")
+        return v

--- a/app/shared/kafka/models/upload_event.py
+++ b/app/shared/kafka/models/upload_event.py
@@ -21,6 +21,14 @@ class UploadEvent(BaseModel):
     type_episode: str | None = Field(
         None, description="main | aftershow — определяет paywall для платных publisher'ов"
     )
+    paywall_tier: str | None = Field(
+        None,
+        description=(
+            "Явный id/уровень платного тира. Платный publisher мапит его в свою "
+            "терминологию (Boosty → level_id, sponsr → уровень, VK Donut → donut-only). "
+            "None → публичный пост (если type_episode тоже не aftershow)."
+        ),
+    )
 
     @field_validator("status")
     @classmethod

--- a/app/shared/kafka/schemas/boosty_event.avsc
+++ b/app/shared/kafka/schemas/boosty_event.avsc
@@ -1,0 +1,21 @@
+{
+  "type": "record",
+  "name": "BoostyEvent",
+  "namespace": "podboxbot",
+  "fields": [
+    {"name": "event_type", "type": "string", "doc": "Тип события: request | result"},
+    {"name": "username", "type": "string"},
+    {"name": "status", "type": ["null", "string"], "default": null, "doc": "pending | success | failure"},
+    {"name": "error", "type": ["null", "string"], "default": null},
+    {"name": "chat_id", "type": ["null", "string"], "default": null},
+    {"name": "message_id", "type": ["null", "string"], "default": null},
+    {"name": "number", "type": "string", "doc": "Номер эпизода"},
+    {"name": "title", "type": "string"},
+    {"name": "comment", "type": "string", "doc": "Тело поста / описание эпизода"},
+    {"name": "chapters", "type": {"type": "array", "items": {"type": "array", "items": "string"}}, "doc": "Таймлайн [[time, name], ...]"},
+    {"name": "tags", "type": {"type": "array", "items": "string"}},
+    {"name": "type_episode", "type": ["null", "string"], "default": null, "doc": "main | aftershow — определяет paywall для платных publisher'ов"},
+    {"name": "paywall_tier", "type": ["null", "string"], "default": null, "doc": "Имя уровня подписки Boosty или его id; приоритетнее type_episode"},
+    {"name": "post_id", "type": ["null", "string"], "default": null, "doc": "ID созданного поста на Boosty (в success-result)"}
+  ]
+}

--- a/app/shared/kafka/schemas/upload_event.avsc
+++ b/app/shared/kafka/schemas/upload_event.avsc
@@ -16,6 +16,7 @@
     {"name": "error", "type": ["null", "string"], "default": null},
     {"name": "message_id", "type": ["null", "string"], "default": null},
     {"name": "chat_id", "type": ["null", "string"], "default": null},
-    {"name": "type_episode", "type": ["null", "string"], "default": null, "doc": "main | aftershow — определяет paywall для платных publisher'ов"}
+    {"name": "type_episode", "type": ["null", "string"], "default": null, "doc": "main | aftershow — определяет paywall для платных publisher'ов"},
+    {"name": "paywall_tier", "type": ["null", "string"], "default": null, "doc": "Явный id/уровень платного тира; платный publisher мапит в свою терминологию (Boosty → level_id и т.д.)"}
   ]
 }

--- a/app/shared/publishers/base.py
+++ b/app/shared/publishers/base.py
@@ -54,6 +54,16 @@ class BasePublisher(ABC):
     group_id: str
     """Consumer group для horizontal-scalability (на одного potребителя)."""
 
+    # --- Capability flags ---
+    # Декларативные дефолты. Оркестратор/роутер может смотреть на них, чтобы
+    # не слать событие туда, где возможность не реализована (например, не
+    # отправлять paid_only-эпизод в publisher с supports_paywall=False).
+    supports_paywall: bool = False
+    """True если publisher умеет ставить paywall/tier (Boosty, sponsr, VK Donut)."""
+
+    supports_scheduled: bool = False
+    """True если publisher умеет отложенную публикацию по расписанию."""
+
     def __init__(
         self,
         kafka_server: str | None = None,
@@ -86,14 +96,33 @@ class BasePublisher(ABC):
         соберёт и отправит failure-event.
         """
 
+    async def _ensure_auth(self) -> None:
+        """Гарантирует валидные креды перед publish. No-op по умолчанию.
+
+        Token-based publisher'ы (Boosty: access/refresh/device из auth.json)
+        переопределяют: загрузить токен из файла, при истечении/401 — refresh
+        и пересохранить. Blocking file IO заворачивать в asyncio.to_thread.
+        Бесплатные publisher'ы (FTP, WordPress) ничего не делают.
+
+        Вызывается базой в начале каждого _handle; исключение здесь
+        конвертируется в failure-event так же, как из publish().
+        """
+        return None
+
     @staticmethod
     def is_paywalled(event) -> bool:
         """True если эпизод предназначен для платной аудитории.
 
-        Платные publisher'ы (VK Donut, Boosty, Patreon, sponsr) должны
-        выставлять соответствующий tier/donut_paid флаг. Бесплатные
-        (FTP, WordPress) могут это поле игнорировать.
+        Два источника правды, в порядке приоритета:
+        1. Явный `paywall_tier` — если задан, эпизод платный (любой непустой
+           tier означает «только для подписчиков этого уровня и выше»).
+        2. `type_episode == "aftershow"` — исторический неявный маркер.
+
+        Платные publisher'ы (VK Donut, Boosty, Patreon, sponsr) выставляют
+        tier; бесплатные (FTP, WordPress) поле игнорируют.
         """
+        if getattr(event, "paywall_tier", None):
+            return True
         return getattr(event, "type_episode", None) == "aftershow"
 
     def event_key(self, event) -> str:
@@ -138,6 +167,7 @@ class BasePublisher(ABC):
 
         start = time.time()
         try:
+            await self._ensure_auth()
             await self.publish(event)
             self.metrics.success({"target": str(key)})
         except Exception as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,25 @@ services:
       - .env:/app/.env
       - wordpress_data:/app/data
 
+  publisher_boosty:
+    container_name: podboxbot_publisher_boosty
+    build:
+      context: .
+      dockerfile: ./app/publishers/Boosty/Dockerfile
+    restart: always
+    depends_on:
+      kafka-init:
+        condition: service_completed_successfully
+      schema-registry:
+        condition: service_healthy
+      pushgateway:
+        condition: service_started
+    networks:
+      - podboxbot_network
+    volumes:
+      - .env:/app/.env
+      - boosty_data:/app/data
+
   # METRICS AND MONITORING
 
   pushgateway:
@@ -405,6 +424,8 @@ volumes:
   kafka_data:
     driver: local
   wordpress_data:
+    driver: local
+  boosty_data:
     driver: local
   files:
     driver: local

--- a/tests/unit/publishers/boosty/conftest.py
+++ b/tests/unit/publishers/boosty/conftest.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Boosty/main.py uses bare ``from boosty_client import ...`` (and boosty_client
+# imports ``from content import ...``) — those resolve in-container because
+# main.py runs from /app with the service sources alongside it. Outside the
+# container that dir isn't on the path, so add it here (mirrors WordPress).
+_BOOSTY_SRC = Path(__file__).resolve().parents[4] / "app" / "publishers" / "Boosty"
+if str(_BOOSTY_SRC) not in sys.path:
+    sys.path.insert(0, str(_BOOSTY_SRC))
+
+
+@pytest.fixture
+def sample_boosty_post_info():
+    return {
+        "number": "123",
+        "title": "123. Тестовый эпизод",
+        "comment": "Описание тестового эпизода.\nВторой абзац.",
+        "chapters": [["00:00:00", "Начало"], ["00:10:00", "Середина"]],
+        "tags": ["тест", "подкаст"],
+    }
+
+
+@pytest.fixture
+def sample_boosty_event_dict(sample_boosty_post_info):
+    return {
+        "event_type": "request",
+        "username": "testuser",
+        "status": "pending",
+        "chat_id": "12345",
+        "message_id": "67890",
+        "type_episode": "main",
+        **sample_boosty_post_info,
+    }

--- a/tests/unit/publishers/boosty/test_boosty_handler.py
+++ b/tests/unit/publishers/boosty/test_boosty_handler.py
@@ -1,0 +1,125 @@
+"""Tests for the Boosty publisher Kafka handler (main.py) и модели события."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.shared.kafka.models.boosty_event import BoostyEvent
+
+
+@pytest.fixture
+def mock_producer():
+    producer = AsyncMock()
+    producer.send = AsyncMock()
+    return producer
+
+
+@pytest.fixture
+def patched_publisher(monkeypatch):
+    """Подменяет _publisher.client на AsyncMock (instance создаётся при импорте).
+
+    resolve_level_id → "777", create_post → "post-1", ensure_auth → no-op.
+    """
+    from app.publishers.Boosty import main
+
+    client = AsyncMock()
+    client.ensure_auth = AsyncMock(return_value=None)
+    client.resolve_level_id = AsyncMock(return_value="777")
+    client.create_post = AsyncMock(return_value="post-1")
+    monkeypatch.setattr(main._publisher, "client", client)
+    # Дефолтные уровни, чтобы happy-path не падал на «level not configured».
+    monkeypatch.setattr(main, "BOOSTY_FREE_LEVEL", "Бесплатный")
+    monkeypatch.setattr(main, "BOOSTY_AFTERSHOW_LEVEL", "Подписка")
+    return main, client
+
+
+class TestHandleUpload:
+    @pytest.mark.asyncio
+    async def test_successful_publish(self, sample_boosty_event_dict, mock_producer, patched_publisher):
+        main, client = patched_publisher
+        await main.handle_upload(sample_boosty_event_dict, mock_producer)
+
+        client.create_post.assert_awaited_once()
+        mock_producer.send.assert_called_once()
+        result = mock_producer.send.call_args[0][1]
+        assert result["event_type"] == "result"
+        assert result["status"] == "success"
+        assert result["post_id"] == "post-1"
+
+    @pytest.mark.asyncio
+    async def test_main_episode_uses_free_level(
+        self, sample_boosty_event_dict, mock_producer, patched_publisher, monkeypatch
+    ):
+        main, client = patched_publisher
+        monkeypatch.setattr(main, "BOOSTY_FREE_LEVEL", "Бесплатный")
+        sample_boosty_event_dict["type_episode"] = "main"
+
+        await main.handle_upload(sample_boosty_event_dict, mock_producer)
+
+        client.resolve_level_id.assert_awaited_once_with("Бесплатный")
+
+    @pytest.mark.asyncio
+    async def test_aftershow_uses_paid_level(
+        self, sample_boosty_event_dict, mock_producer, patched_publisher, monkeypatch
+    ):
+        main, client = patched_publisher
+        monkeypatch.setattr(main, "BOOSTY_AFTERSHOW_LEVEL", "Подписка")
+        sample_boosty_event_dict["type_episode"] = "aftershow"
+
+        await main.handle_upload(sample_boosty_event_dict, mock_producer)
+
+        client.resolve_level_id.assert_awaited_once_with("Подписка")
+
+    @pytest.mark.asyncio
+    async def test_explicit_paywall_tier_wins(self, sample_boosty_event_dict, mock_producer, patched_publisher):
+        main, client = patched_publisher
+        sample_boosty_event_dict["type_episode"] = "main"
+        sample_boosty_event_dict["paywall_tier"] = "VIP"
+
+        await main.handle_upload(sample_boosty_event_dict, mock_producer)
+
+        client.resolve_level_id.assert_awaited_once_with("VIP")
+
+    @pytest.mark.asyncio
+    async def test_failure_emits_failure_event(self, sample_boosty_event_dict, mock_producer, patched_publisher):
+        main, client = patched_publisher
+        client.create_post.side_effect = RuntimeError("boom")
+
+        await main.handle_upload(sample_boosty_event_dict, mock_producer)
+
+        result = mock_producer.send.call_args[0][1]
+        assert result["status"] == "failure"
+        assert "boom" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_payload_skipped(self, mock_producer, patched_publisher):
+        main, _ = patched_publisher
+        await main.handle_upload({"invalid": "data"}, mock_producer)
+        mock_producer.send.assert_not_called()
+
+
+class TestBoostyEventModel:
+    def test_valid_event(self, sample_boosty_event_dict):
+        event = BoostyEvent(**sample_boosty_event_dict)
+        assert event.number == "123"
+        assert event.event_type == "request"
+        assert event.chapters == [["00:00:00", "Начало"], ["00:10:00", "Середина"]]
+
+    def test_invalid_status(self, sample_boosty_event_dict):
+        sample_boosty_event_dict["status"] = "invalid_status"
+        with pytest.raises(ValidationError):
+            BoostyEvent(**sample_boosty_event_dict)
+
+    def test_paywall_fields_default_none(self, sample_boosty_event_dict):
+        sample_boosty_event_dict.pop("type_episode", None)
+        event = BoostyEvent(**sample_boosty_event_dict)
+        assert event.paywall_tier is None
+        assert event.type_episode is None
+        assert event.post_id is None
+
+    def test_model_dump_roundtrip(self, sample_boosty_event_dict):
+        event = BoostyEvent(**sample_boosty_event_dict)
+        dump = event.model_dump()
+        assert dump["tags"] == ["тест", "подкаст"]
+        assert BoostyEvent(**dump) == event

--- a/tests/unit/publishers/boosty/test_content.py
+++ b/tests/unit/publishers/boosty/test_content.py
@@ -1,0 +1,57 @@
+"""Тесты чистого draft.js-билдера (без зависимости от либы boosty)."""
+
+import json
+
+from app.publishers.Boosty.content import build_post_data
+
+
+def _parse(data: str) -> list[dict]:
+    return json.loads(data)
+
+
+class TestBuildPostData:
+    def test_returns_json_string(self):
+        out = build_post_data("hello")
+        assert isinstance(out, str)
+        assert isinstance(_parse(out), list)
+
+    def test_text_block_shape_matches_reference(self):
+        # Формат подтверждён реверсом HOCKI1/py_boosty_api:
+        # text-блок + BLOCK_END, content — вложенный json.dumps.
+        blocks = _parse(build_post_data("hello"))
+        assert blocks[0]["type"] == "text"
+        assert blocks[0]["modificator"] == ""
+        assert json.loads(blocks[0]["content"]) == ["hello", "unstyled", []]
+        assert blocks[1] == {"type": "text", "content": "", "modificator": "BLOCK_END"}
+
+    def test_paragraphs_split_on_newline(self):
+        blocks = _parse(build_post_data("first\nsecond"))
+        texts = [json.loads(b["content"])[0] for b in blocks if b["modificator"] == ""]
+        assert texts == ["first", "second"]
+
+    def test_blank_lines_skipped(self):
+        blocks = _parse(build_post_data("a\n\n   \nb"))
+        texts = [json.loads(b["content"])[0] for b in blocks if b["modificator"] == ""]
+        assert texts == ["a", "b"]
+
+    def test_chapters_appended(self):
+        blocks = _parse(build_post_data("body", chapters=[["00:00", "Intro"], ["01:00", "Mid"]]))
+        texts = [json.loads(b["content"])[0] for b in blocks if b["modificator"] == ""]
+        assert "00:00 — Intro" in texts
+        assert "01:00 — Mid" in texts
+
+    def test_empty_body_produces_non_empty_post(self):
+        # Boosty не принимает пустой data — даём хотя бы один блок.
+        blocks = _parse(build_post_data(""))
+        assert len(blocks) >= 2
+        assert blocks[-1]["modificator"] == "BLOCK_END"
+
+    def test_unicode_not_escaped(self):
+        out = build_post_data("Привет")
+        # ensure_ascii=False на обоих слоях → кириллица не \uXXXX.
+        assert "Привет" in out
+
+    def test_one_element_chapter_uses_first(self):
+        blocks = _parse(build_post_data("", chapters=[["solo"]]))
+        texts = [json.loads(b["content"])[0] for b in blocks if b["modificator"] == ""]
+        assert "solo" in texts


### PR DESCRIPTION
## Что

Новый publisher-микросервис **Boosty** + минимальная общая обвязка, поверх актуального `main`.

### Boosty publisher
- `app/publishers/Boosty/` — `main.py` (Kafka-loop через `BasePublisher`), `boosty_client.py` (тонкая обёртка над `barsikus007/boosty` с сырым create-post для привязки к `subscription_level_id`), `content.py` (сборка draft.js-блоков), Dockerfile, pyproject.
- `BoostyEvent` + `.avsc` + топики `publisher.boosty.{upload,result}`.
- Tier-логика: явный `paywall_tier` приоритетен; иначе aftershow → платный уровень, остальное → бесплатный.

### Общая обвязка
- `BasePublisher`: флаги `supports_paywall`/`supports_scheduled`, хук `_ensure_auth` (вызывается в `_handle`), `is_paywalled` теперь учитывает `paywall_tier`.
- `UploadEvent` (+ `.avsc`): поле `paywall_tier`.
- `shared.config`: 6 `BOOSTY_*` переменных; `.env.example`, `docker-compose` (service + volume), `.gitignore` (`boosty_auth.json`).
- CI: job `test-publisher-boosty`; conftest добавляет src-dir в `sys.path` для bare-импортов.

## Проверки
- ruff check + format — чисто
- Тесты: Boosty 18 ✅ · WordPress 23 ✅ · FTP 8 ✅ · config/kafka 8 ✅ (без регрессий)