### PR TITLE
fix(compose): default to direct connection over tun2socks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ app/
     ├── config/           # pydantic-settings, один источник правды для микросервисов
     └── kafka/            # общий KafkaProducer/Consumer + Avro-схемы
 configs/                  # prometheus.yml, loki, grafana datasources, alloy
-docker-compose.yml        # стек С tun2socks (для хостов за блокировкой)
-docker-compose.direct.yml # стек БЕЗ tun2socks (для хостов с прямым доступом)
+docker-compose.yml          # стек БЕЗ tun2socks (дефолт, прямой коннект)
+docker-compose.tun2socks.yml # стек С tun2socks (для хостов за блокировкой)
 utils/bootstrap.sh        # первичный деплой на чистый prod
 .env.example              # шаблон переменных окружения
 ```
@@ -104,22 +104,22 @@ docker compose version   # должно показать v2.x
 
 3. **Выбрать compose-файл:**
 
+   - Хост за рубежом / есть прямой доступ к Telegram DC → используй
+     дефолтный `docker-compose.yml` (без прокси-слоя).
    - Хост в РФ / за блокировкой и есть SOCKS-прокси (например xray на
-     `localhost:10808`) → используй дефолтный `docker-compose.yml`
+     `localhost:10808`) → `docker-compose.tun2socks.yml`
      (заворачивает трафик telegram-bot-api через `tun2socks`).
-   - Хост за рубежом / есть прямой доступ к Telegram DC →
-     `docker-compose.direct.yml` (без прокси-слоя).
 
 4. **Запустить bootstrap:**
 
    ```bash
    chmod +x utils/bootstrap.sh
 
-   # С tun2socks (дефолт)
+   # Прямой коннект (дефолт)
    ./utils/bootstrap.sh
 
-   # Без tun2socks
-   ./utils/bootstrap.sh -f docker-compose.direct.yml
+   # С tun2socks (за блокировкой)
+   ./utils/bootstrap.sh -f docker-compose.tun2socks.yml
    ```
 
    Скрипт проходит 7 фаз:

--- a/docker-compose.tun2socks.yml
+++ b/docker-compose.tun2socks.yml
@@ -1,33 +1,54 @@
-# docker-compose.direct.yml — конфиг БЕЗ tun2socks.
+# docker-compose.tun2socks.yml — конфиг С tun2socks.
 #
-# Используй, когда хост имеет прямой доступ к Telegram DC (нет блокировок
-# на сетевом уровне). telegram-bot-api ходит напрямую, без SOCKS-прокси.
+# Для хостов, где Telegram заблокирован на сетевом уровне: telegram-bot-api
+# заворачивается в SOCKS-прокси на хосте (xray на :10808). Дефолтный файл
+# docker-compose.yml — то же самое без прокси, для хостов с прямым доступом.
 #
 # Запуск:
-#   docker compose -f docker-compose.direct.yml up -d --build
-#
-# Или через bootstrap.sh:
-#   ./utils/bootstrap.sh --file docker-compose.direct.yml
-#
-# Парный файл docker-compose.yml — версия С tun2socks (для прода за
-# блокировками). Всё, что отличается, — это сервис tun2socks (отсутствует
-# здесь) и сетевая конфигурация api (использует обычную bridge-сеть
-# вместо netns tun2socks).
+#   docker compose -f docker-compose.tun2socks.yml up -d --build
+#   ./utils/bootstrap.sh -f docker-compose.tun2socks.yml   # через bootstrap
+#   ./utils/bootstrap.sh                                   # дефолт — без tun2socks
 
 services:
+  # Заворачивает весь трафик telegram-bot-api в хостовый SOCKS (xray на :10808),
+  # т.к. сам telegram-bot-api ходит к DC Telegram по MTProto и HTTP(S)_PROXY игнорирует.
+  tun2socks:
+    container_name: podboxbot_tun2socks
+    image: xjasonlyu/tun2socks:latest
+    restart: always
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      LOGLEVEL: info
+      PROXY: socks5://host.docker.internal:10808
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    expose:
+      - 8081
+    networks:
+      podboxbot_network:
+        aliases:
+          - api
+
   api:
     container_name: podboxbot_telegram_api
     image: aiogram/telegram-bot-api:latest
     restart: always
+    # делит сетевой namespace с tun2socks — весь исходящий трафик идёт через SOCKS
+    network_mode: "service:tun2socks"
+    depends_on:
+      tun2socks:
+        condition: service_started
     environment:
       TELEGRAM_API_ID: ${TELEGRAM_SERVER_API_ID}
       TELEGRAM_API_HASH: ${TELEGRAM_SERVER_API_HASH}
       TELEGRAM_LOCAL: ${LOCAL}
       TELEGRAM_VERBOSITY: 3
-    expose:
-      - 8081
-    networks:
-      - podboxbot_network
     volumes:
       - telegram-bot-api-data:/var/lib/telegram-bot-api
 
@@ -39,10 +60,15 @@ services:
     build:
       context: .
       dockerfile: ./app/bot/Dockerfile
+      # Без target классический docker-сборщик (без BuildKit) проходит ВСЕ
+      # stage’и подряд, включая `test`, где poetry install --with dev
+      # тянет aiogram-tests из git и падает на poetry/dulwich-баге.
       target: final
     environment:
       TG_SERVER: "http://api:8081"
-      # REDIS_URL собирается в bot/config.py из REDIS_PASSWORD (с urlencoding).
+      # REDIS_URL не передаём — бот собирает его сам в config.py из
+      # REDIS_PASSWORD с URL-encoding (защита от спецсимволов в пароле).
+      # REDIS_PASSWORD приходит через .env-mount ниже.
     depends_on:
       api:
         condition: service_started
@@ -96,6 +122,7 @@ services:
     container_name: podboxbot_kafka
     restart: always
     environment:
+      # --- Основные настройки KRaft ---
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_NODE_ID: 1
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
@@ -103,10 +130,16 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+
+      # --- Поведение брокера ---
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+      # --- Хранилище данных ---
       KAFKA_LOG_DIRS: /var/lib/kafka/data
+
+      # --- Безопасность и производительность ---
       KAFKA_NUM_PARTITIONS: 3
       KAFKA_DELETE_TOPIC_ENABLE: "true"
     expose:
@@ -120,6 +153,7 @@ services:
       retries: 5
     volumes:
       - kafka_data:/var/lib/kafka/data
+
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.5.0
@@ -136,10 +170,15 @@ services:
     networks:
       - podboxbot_network
     healthcheck:
+      # cub sr-ready — официальная тулза в cp-schema-registry образе,
+      # проверяет JVM-ready + Kafka-connection. Надёжнее, чем curl /subjects
+      # (которая на старте может вернуть 500 пока _schemas-топик создаётся).
       test: ["CMD", "cub", "sr-ready", "localhost", "8081", "30"]
       interval: 10s
       timeout: 30s
       retries: 5
+      # На голом железе SR прогревается 30-60с (joining Kafka, создание
+      # _schemas-топика). start_period подавляет «промахи» в это окно.
       start_period: 60s
 
   kafka-init:
@@ -173,6 +212,7 @@ services:
       - podboxbot_network
     environment:
       - SCHEMA_REGISTRY_URL=http://schema-registry:8081
+
 
   # PUBLISHERS
 
@@ -275,6 +315,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
       - ./configs/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./configs/grafana/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+      - ./configs/grafana/dashbords:/etc/grafana/dashboards
       - grafana_data:/var/lib/grafana
     networks:
       - monitoring

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,29 @@
-# docker-compose.yml — конфиг С tun2socks (дефолт).
+# docker-compose.yml — конфиг БЕЗ tun2socks (дефолт, прямой коннект).
 #
-# Для хостов, где Telegram заблокирован на сетевом уровне: telegram-bot-api
-# заворачивается в SOCKS-прокси на хосте (xray на :10808). Парный файл
-# docker-compose.direct.yml — то же самое без прокси, для хостов с прямым
-# доступом.
+# Используй, когда хост имеет прямой доступ к Telegram DC (нет блокировок
+# на сетевом уровне). telegram-bot-api ходит напрямую, без SOCKS-прокси.
+# Парный файл docker-compose.tun2socks.yml — версия С tun2socks (для прода
+# за блокировками): заворачивает трафик telegram-bot-api в хостовый SOCKS.
 #
 # Запуск:
-#   docker compose up -d --build              # этот файл (с tun2socks)
+#   docker compose up -d --build              # этот файл (прямой коннект)
 #   ./utils/bootstrap.sh                      # через bootstrap, по умолчанию этот файл
-#   ./utils/bootstrap.sh -f docker-compose.direct.yml   # без tun2socks
+#   ./utils/bootstrap.sh -f docker-compose.tun2socks.yml   # с tun2socks
 
 services:
-  # Заворачивает весь трафик telegram-bot-api в хостовый SOCKS (xray на :10808),
-  # т.к. сам telegram-bot-api ходит к DC Telegram по MTProto и HTTP(S)_PROXY игнорирует.
-  tun2socks:
-    container_name: podboxbot_tun2socks
-    image: xjasonlyu/tun2socks:latest
-    restart: always
-    cap_add:
-      - NET_ADMIN
-    devices:
-      - /dev/net/tun
-    environment:
-      LOGLEVEL: info
-      PROXY: socks5://host.docker.internal:10808
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    dns:
-      - 1.1.1.1
-      - 8.8.8.8
-    expose:
-      - 8081
-    networks:
-      podboxbot_network:
-        aliases:
-          - api
-
   api:
     container_name: podboxbot_telegram_api
     image: aiogram/telegram-bot-api:latest
     restart: always
-    # делит сетевой namespace с tun2socks — весь исходящий трафик идёт через SOCKS
-    network_mode: "service:tun2socks"
-    depends_on:
-      tun2socks:
-        condition: service_started
     environment:
       TELEGRAM_API_ID: ${TELEGRAM_SERVER_API_ID}
       TELEGRAM_API_HASH: ${TELEGRAM_SERVER_API_HASH}
       TELEGRAM_LOCAL: ${LOCAL}
       TELEGRAM_VERBOSITY: 3
+    expose:
+      - 8081
+    networks:
+      - podboxbot_network
     volumes:
       - telegram-bot-api-data:/var/lib/telegram-bot-api
 

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -28,7 +28,7 @@ cd "$REPO_ROOT"
 BACKUP_DIR="$REPO_ROOT/backups/$(date -u +%Y-%m-%dT%H-%M-%SZ)"
 # COMPOSE — команда compose; задаётся в preflight() по результату детекта v1/v2.
 # COMPOSE_FILE — какой compose-файл использовать. По умолчанию docker-compose.yml
-# (с tun2socks); для прямого режима без прокси передай -f docker-compose.direct.yml.
+# (прямой коннект); для режима за блокировкой передай -f docker-compose.tun2socks.yml.
 COMPOSE=""
 COMPOSE_FILE="docker-compose.yml"
 SMOKE_TOPIC="bootstrap.smoke.$(date -u +%s)"
@@ -62,7 +62,7 @@ Bootstraps PodBoxBot stack on a fresh prod host.
 
 Options:
   -f, --file FILE   compose-файл (по умолчанию: docker-compose.yml).
-                    Для прямого режима без tun2socks: docker-compose.direct.yml.
+                    Для режима за блокировкой с tun2socks: docker-compose.tun2socks.yml.
   -h, --help        эта справка.
 EOF
 }


### PR DESCRIPTION
Меняет приоритет подключения: дефолтный стек теперь идёт напрямую к Telegram DC, а вариант с tun2socks вынесен в отдельный файл.

## Изменения
- `docker-compose.yml` — прямой коннект (без tun2socks), `api` на обычной bridge-сети. Дефолт для `docker compose up` и `bootstrap.sh`.
- `docker-compose.tun2socks.yml` — новый файл с tun2socks (для хостов за блокировкой), бывший `docker-compose.yml`.
- `docker-compose.direct.yml` удалён — его роль теперь у дефолтного файла.
- Оба compose-файла собраны из одного полного стека, поэтому больше не разъезжаются (grafana-дашборды и т.п.).
- `utils/bootstrap.sh` и `README.md` обновлены: режим с tun2socks теперь `-f docker-compose.tun2socks.yml`.

## Запуск
```bash
./utils/bootstrap.sh                                 # прямой коннект (дефолт)
./utils/bootstrap.sh -f docker-compose.tun2socks.yml # за блокировкой
```

Оба файла проходят `docker compose config -q`.