### PR TITLE
feat(reboot): make stack resilient to host reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,30 @@ docker compose build --no-cache bot publisher_ftp publisher_wordpress publisher_
 docker compose up -d
 ```
 
+### Устойчивость к ребуту хоста
+
+После перезагрузки хоста Docker поднимает контейнеры по `restart: always`
+**без** соблюдения `depends_on` (это правило уровня `docker compose up`, а не
+рантайма демона). Поэтому бот/publisher'ы могут стартовать раньше Kafka и
+Schema Registry. Защита выстроена в три слоя:
+
+1. **In-process readiness-гейты** (`app/shared/kafka/wait_for_kafka.py`):
+   каждый consumer ждёт Kafka + Schema Registry перед подпиской, каждый
+   producer — перед первой публикацией. Порядок старта перестаёт иметь
+   значение; события не теряются в окне прогрева.
+2. **Супервайзер result-consumer'ов в боте**: если consumer-loop падает или
+   readiness истекает по таймауту — он перезапускается. Бот не остаётся
+   «полуживым» (Telegram отвечает, а приём result-событий мёртв).
+3. **systemd-юнит** (`deploy/podboxbot.service`): на загрузке поднимает стек
+   оркестрованно (`docker compose up -d`, depends_on соблюдается), на
+   ребуте/останове — graceful `docker compose stop` (Kafka успевает дописать
+   KRaft-логи → нет коррупции `kafka_data`). Установка — см. комментарий в
+   самом файле юнита. После `systemctl enable --now` любой `reboot` (в т.ч.
+   по cron) проходит безопасно.
+
+Слои 1–2 работают сами по себе; слой 3 рекомендуется на проде, который
+регулярно перезагружается.
+
 ## Разработка
 
 - Локальные venv'ы по сервисам:

--- a/app/bot/main.py
+++ b/app/bot/main.py
@@ -105,32 +105,42 @@ async def on_startup():
     from services import kafka_router
     from services.kafka.handlers import upload_event  # noqa: F401 — регистрирует хендлеры
 
-    # FTP result consumer
-    ftp_consumer = KafkaConsumer(
-        kafka_server="kafka:9092",
-        schema_registry_url="http://schema-registry:8081",
-        topic="publisher.ftp.result",
-        group_id="publisher.ftp.result.group",
-    )
-    _ftp_task = asyncio.create_task(ftp_consumer.start(kafka_router.route))  # noqa: RUF006
+    # Каждый result-топик слушается в отдельной supervised-задаче. Сам
+    # consumer.start() уже дожидается готовности Kafka/Schema Registry, но
+    # readiness-ожидание может истечь по таймауту и поднять исключение, а сам
+    # poll-loop теоретически может завершиться. Супервайзер ловит любой выход
+    # и перезапускает consumer — так бот не остаётся «полуживым» (Telegram
+    # отвечает, а приём result-событий молча мёртв) после ребута хоста.
+    result_topics = [
+        ("publisher.ftp.result", "publisher.ftp.result.group"),
+        ("publisher.wordpress.result", "publisher.wordpress.result.group"),
+        ("publisher.boosty.result", "publisher.boosty.result.group"),
+    ]
+    for topic, group_id in result_topics:
+        consumer = KafkaConsumer(
+            kafka_server="kafka:9092",
+            schema_registry_url="http://schema-registry:8081",
+            topic=topic,
+            group_id=group_id,
+        )
+        _task = asyncio.create_task(_supervise_consumer(consumer, kafka_router.route))  # noqa: RUF006
 
-    # WordPress result consumer
-    wp_consumer = KafkaConsumer(
-        kafka_server="kafka:9092",
-        schema_registry_url="http://schema-registry:8081",
-        topic="publisher.wordpress.result",
-        group_id="publisher.wordpress.result.group",
-    )
-    _wp_task = asyncio.create_task(wp_consumer.start(kafka_router.route))  # noqa: RUF006
 
-    # Boosty result consumer
-    boosty_consumer = KafkaConsumer(
-        kafka_server="kafka:9092",
-        schema_registry_url="http://schema-registry:8081",
-        topic="publisher.boosty.result",
-        group_id="publisher.boosty.result.group",
-    )
-    _boosty_task = asyncio.create_task(boosty_consumer.start(kafka_router.route))  # noqa: RUF006
+async def _supervise_consumer(consumer: "KafkaConsumer", handler, restart_delay: float = 5.0) -> None:
+    """Перезапускает consumer-loop при любом выходе/падении.
+
+    consumer.start() в норме блокирует навсегда; вернуться/упасть он может
+    только если зависимости не поднялись (readiness-таймаут) или poll-loop
+    словил фатальную ошибку. В этом случае ждём и поднимаем заново — бот
+    самовосстанавливается без вмешательства.
+    """
+    while True:
+        try:
+            await consumer.start(handler)
+            logger.warning(f"[supervisor] consumer for {consumer.topic} exited; restarting in {restart_delay:.0f}s")
+        except Exception as e:
+            logger.exception(f"[supervisor] consumer for {consumer.topic} crashed: {e!r}; restarting in {restart_delay:.0f}s")
+        await asyncio.sleep(restart_delay)
 
 
 @logger.catch

--- a/app/bot/main.py
+++ b/app/bot/main.py
@@ -139,7 +139,9 @@ async def _supervise_consumer(consumer: "KafkaConsumer", handler, restart_delay:
             await consumer.start(handler)
             logger.warning(f"[supervisor] consumer for {consumer.topic} exited; restarting in {restart_delay:.0f}s")
         except Exception as e:
-            logger.exception(f"[supervisor] consumer for {consumer.topic} crashed: {e!r}; restarting in {restart_delay:.0f}s")
+            logger.exception(
+                f"[supervisor] consumer for {consumer.topic} crashed: {e!r}; restarting in {restart_delay:.0f}s"
+            )
         await asyncio.sleep(restart_delay)
 
 

--- a/app/shared/kafka/consumer.py
+++ b/app/shared/kafka/consumer.py
@@ -5,6 +5,8 @@ from confluent_kafka import KafkaError
 from confluent_kafka.avro import AvroConsumer, SerializerError
 from loguru import logger
 
+from shared.kafka.wait_for_kafka import wait_for_kafka_stack
+
 _RETRY_INITIAL_DELAY = 2.0  # seconds
 _RETRY_MAX_DELAY = 60.0  # seconds
 _RETRY_MULTIPLIER = 2.0
@@ -20,6 +22,8 @@ class KafkaConsumer:
         max_workers: int = 4,
     ):
         self.topic = topic
+        self._kafka_server = kafka_server
+        self._schema_registry_url = schema_registry_url
         self._running = True
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
 
@@ -33,7 +37,15 @@ class KafkaConsumer:
         )
 
     async def start(self, handler):
-        """Async Kafka polling loop with retry backoff on transient errors."""
+        """Async Kafka polling loop with retry backoff on transient errors.
+
+        Перед подпиской ждём готовности Kafka и Schema Registry. Это снимает
+        зависимость от порядка старта контейнеров: после ребута хоста, где
+        `depends_on` не соблюдается, consumer просто дождётся зависимостей,
+        вместо того чтобы стартовать в сломанном состоянии и терять события.
+        """
+        await wait_for_kafka_stack(self._kafka_server, self._schema_registry_url)
+
         self.consumer.subscribe([self.topic])
         logger.info(f"[AsyncAvroConsumer] Listening {self.topic}")
 
@@ -71,9 +83,16 @@ class KafkaConsumer:
                 _task = asyncio.create_task(handler(value))  # noqa: RUF006
 
             except SerializerError as e:
+                # Обычно schema registry недоступна/схема не зарегистрирована.
+                # Пауза, чтобы не молотить broker и логи в плотном цикле, пока
+                # зависимость не восстановится.
                 logger.error(f"[Kafka Avro] Serialization error: {e}")
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(retry_delay * _RETRY_MULTIPLIER, _RETRY_MAX_DELAY)
             except Exception as e:
                 logger.exception(f"[KafkaConsumer] Unexpected error: {e}")
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(retry_delay * _RETRY_MULTIPLIER, _RETRY_MAX_DELAY)
 
         self.consumer.close()
         logger.info("[AsyncAvroConsumer] Stopped")

--- a/app/shared/kafka/producer.py
+++ b/app/shared/kafka/producer.py
@@ -4,6 +4,8 @@ from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
 from loguru import logger
 
+from shared.kafka.wait_for_kafka import wait_for_kafka_stack
+
 
 class KafkaProducer:
     def __init__(self, kafka_server: str, schema_registry_url: str, value_schema_path: str):
@@ -17,6 +19,7 @@ class KafkaProducer:
         # Kafka и без .avsc по in-container пути (нужно для тестов вне контейнера).
         self.value_schema = None
         self.producer: AvroProducer | None = None
+        self._ready = False
 
     def _ensure_producer(self) -> AvroProducer:
         """Лениво грузит Avro-схему и поднимает AvroProducer (idempotent)."""
@@ -32,6 +35,14 @@ class KafkaProducer:
         return self.producer
 
     async def send(self, topic: str, value: dict):
+        # Перед первой публикацией дожидаемся Kafka + Schema Registry. Иначе
+        # после ребута хоста (где порядок старта не гарантирован) первый send
+        # упал бы на недоступной schema registry, и событие потерялось бы.
+        # Флаг кэширует готовность — на горячем пути проверки нет.
+        if not self._ready:
+            await wait_for_kafka_stack(self.kafka_server, self.schema_registry_url)
+            self._ready = True
+
         producer = self._ensure_producer()
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, lambda: producer.produce(topic=topic, value=value))

--- a/app/shared/kafka/wait_for_kafka.py
+++ b/app/shared/kafka/wait_for_kafka.py
@@ -1,23 +1,83 @@
-import asyncio
+"""Readiness-гейты для Kafka и Schema Registry.
 
-from aiokafka import AIOKafkaProducer
-from aiokafka.errors import KafkaConnectionError
+Зачем: после ребута хоста Docker поднимает контейнеры по `restart: always`
+БЕЗ соблюдения `depends_on` (это конструкция уровня `docker compose up`, а не
+рантайма демона). Значит порядок старта не гарантирован, и бот/publisher'ы
+могут стартовать раньше Kafka/Schema Registry. Эти хелперы заставляют каждый
+сервис дождаться зависимостей перед тем, как подписываться/публиковать —
+тогда порядок старта перестаёт иметь значение.
+
+Реализация намеренно на `confluent_kafka` (есть во ВСЕХ образах) + stdlib
+`urllib` (для Schema Registry). aiokafka/requests есть не везде (Boosty и
+WordPress их не тянут), поэтому импортить их в shared-код нельзя.
+"""
+
+import asyncio
+import time
+import urllib.request
+
+from confluent_kafka.admin import AdminClient
 from loguru import logger
 
-RETRY_INTERVAL = 2
-MAX_RETRIES = 15
+_RETRY_INITIAL_DELAY = 2.0  # seconds
+_RETRY_MAX_DELAY = 30.0  # seconds
+# Суммарный бюджет ожидания на один заход. По истечении — RuntimeError, чтобы
+# вызывающий (supervisor в боте / restart:always у publisher'а) перезапустил
+# заход с чистого листа. Холодный старт Kafka на минипк (JVM + KRaft recovery)
+# спокойно укладывается в этот бюджет.
+_DEFAULT_TIMEOUT = 300.0  # seconds
 
 
-@logger.catch
-async def wait_for_kafka(kafka_server: str):
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            producer = AIOKafkaProducer(bootstrap_servers=kafka_server)
-            await producer.start()
-            await producer.stop()
-            logger.info(f"[Kafka]: Connected on attempt {attempt}")
+def _check_kafka(server: str) -> bool:
+    """Blocking-проба: брокер доступен и отдаёт метадату хотя бы одного брокера."""
+    try:
+        admin = AdminClient({"bootstrap.servers": server, "socket.timeout.ms": 4000})
+        metadata = admin.list_topics(timeout=5)
+        return bool(metadata and metadata.brokers)
+    except Exception:
+        return False
+
+
+def _check_schema_registry(url: str) -> bool:
+    """Blocking-проба: Schema Registry отвечает 200 на GET /subjects."""
+    try:
+        with urllib.request.urlopen(f"{url.rstrip('/')}/subjects", timeout=5) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+async def _wait(name: str, check, target: str, timeout: float) -> None:
+    """Общий цикл ожидания с экспоненциальным backoff'ом до готовности/таймаута."""
+    loop = asyncio.get_event_loop()
+    delay = _RETRY_INITIAL_DELAY
+    deadline = time.monotonic() + timeout
+    attempt = 0
+    while True:
+        attempt += 1
+        if await loop.run_in_executor(None, check, target):
+            logger.info(f"[readiness] {name} ready ({target}) on attempt {attempt}")
             return
-        except KafkaConnectionError:
-            logger.warning(f"[Kafka]: Attempt {attempt}/{MAX_RETRIES} failed, retrying...")
-            await asyncio.sleep(RETRY_INTERVAL)
-    raise RuntimeError(f"Failed to connect to Kafka at {kafka_server}")
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"[readiness] {name} not ready after {timeout:.0f}s ({target})")
+        logger.warning(f"[readiness] {name} not ready ({target}), attempt {attempt}, retry in {delay:.0f}s")
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, _RETRY_MAX_DELAY)
+
+
+async def wait_for_kafka(kafka_server: str, timeout: float = _DEFAULT_TIMEOUT) -> None:
+    await _wait("kafka", _check_kafka, kafka_server, timeout)
+
+
+async def wait_for_schema_registry(schema_registry_url: str, timeout: float = _DEFAULT_TIMEOUT) -> None:
+    await _wait("schema-registry", _check_schema_registry, schema_registry_url, timeout)
+
+
+async def wait_for_kafka_stack(
+    kafka_server: str,
+    schema_registry_url: str,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> None:
+    """Дождаться обоих: сначала брокер, потом Schema Registry (она зависит от Kafka)."""
+    await wait_for_kafka(kafka_server, timeout)
+    await wait_for_schema_registry(schema_registry_url, timeout)

--- a/deploy/podboxbot.service
+++ b/deploy/podboxbot.service
@@ -1,0 +1,42 @@
+# systemd-юнит для оркестрованного старта/останова стека PodBoxBot.
+#
+# ЗАЧЕМ. Docker по `restart: always` поднимает контейнеры после ребута БЕЗ
+# соблюдения `depends_on` — порядок старта не гарантирован. Этот юнит на каждом
+# старте хоста выполняет `docker compose up -d` (порядок depends_on соблюдается),
+# а на остановке/ребуте — `docker compose stop` с запасом времени (graceful
+# shutdown Kafka → нет коррупции kafka_data при «жёстком» ребуте по cron).
+#
+# In-process readiness-гейты (shared/kafka/wait_for_kafka.py) делают стек
+# устойчивым даже без этого юнита — но юнит добавляет graceful shutdown и
+# гарантированный orchestrated up. Это нижний, инфраструктурный слой защиты.
+#
+# УСТАНОВКА на минипк (один раз):
+#   1. Поправь WorkingDirectory ниже под реальный путь к репозиторию.
+#   2. sudo cp deploy/podboxbot.service /etc/systemd/system/podboxbot.service
+#   3. sudo systemctl daemon-reload
+#   4. sudo systemctl enable --now podboxbot.service
+#
+# После этого ЛЮБОЙ `reboot`/`shutdown` (в т.ч. cron брата) проходит через
+# graceful ExecStop, а на загрузке стек поднимается оркестрованно.
+# Проверка: systemctl status podboxbot,  journalctl -u podboxbot -f
+
+[Unit]
+Description=PodBoxBot docker compose stack
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# !!! ПОПРАВЬ ПУТЬ под минипк (где лежит docker-compose.yml) !!!
+WorkingDirectory=/opt/PodBoxBot
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose stop -t 40
+# Старт может занять время на холодной Kafka — не душим таймаутом.
+TimeoutStartSec=0
+# Дать ExecStop спокойно завершить graceful-стоп всех контейнеров.
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.tun2socks.yml
+++ b/docker-compose.tun2socks.yml
@@ -121,6 +121,11 @@ services:
     image: confluentinc/cp-kafka:latest
     container_name: podboxbot_kafka
     restart: always
+    # Дать брокеру дописать KRaft-логи и сняться с группы перед kill при
+    # ребуте/останове — иначе «жёсткий» стоп рискует повредить kafka_data,
+    # после чего consumer'ы/SR ведут себя странно. Парно с ExecStop в
+    # deploy/podboxbot.service (там общий бюджет на стек).
+    stop_grace_period: 60s
     environment:
       # --- Основные настройки KRaft ---
       KAFKA_PROCESS_ROLES: broker,controller

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,11 @@ services:
     image: confluentinc/cp-kafka:latest
     container_name: podboxbot_kafka
     restart: always
+    # Дать брокеру дописать KRaft-логи и сняться с группы перед kill при
+    # ребуте/останове — иначе «жёсткий» стоп рискует повредить kafka_data,
+    # после чего consumer'ы/SR ведут себя странно. Парно с ExecStop в
+    # deploy/podboxbot.service (там общий бюджет на стек).
+    stop_grace_period: 60s
     environment:
       # --- Основные настройки KRaft ---
       KAFKA_PROCESS_ROLES: broker,controller

--- a/tests/unit/kafka/test_producer.py
+++ b/tests/unit/kafka/test_producer.py
@@ -22,10 +22,16 @@ class TestKafkaProducer:
         mock_avro.load.assert_not_called()
         mock_avro_producer.assert_not_called()
 
+    @patch("app.shared.kafka.producer.wait_for_kafka_stack")
     @patch("app.shared.kafka.producer.avro")
     @patch("app.shared.kafka.producer.AvroProducer")
     @pytest.mark.asyncio
-    async def test_send(self, mock_avro_producer_cls, mock_avro):
+    async def test_send(self, mock_avro_producer_cls, mock_avro, mock_wait):
+        # Readiness-гейт — инфраструктурная зависимость; мокаем как и брокер.
+        async def _noop(*args, **kwargs):
+            return None
+
+        mock_wait.side_effect = _noop
         mock_avro.load.return_value = {"type": "record", "name": "test"}
         mock_producer_instance = mock_avro_producer_cls.return_value
         mock_producer_instance.produce = MagicMock()

--- a/tests/unit/kafka/test_wait_for_kafka.py
+++ b/tests/unit/kafka/test_wait_for_kafka.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 import pytest
-
 from app.shared.kafka import wait_for_kafka as wk
 
 

--- a/tests/unit/kafka/test_wait_for_kafka.py
+++ b/tests/unit/kafka/test_wait_for_kafka.py
@@ -1,0 +1,55 @@
+"""Tests for the Kafka/Schema-Registry readiness gates."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.shared.kafka import wait_for_kafka as wk
+
+
+class TestWaitForKafka:
+    @pytest.mark.asyncio
+    async def test_returns_when_ready_immediately(self):
+        """Готовая зависимость → возврат без задержек."""
+        with patch.object(wk, "_check_kafka", return_value=True) as chk:
+            await wk.wait_for_kafka("kafka:9092", timeout=5)
+        chk.assert_called_once_with("kafka:9092")
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds(self):
+        """Пара промахов, затем готовность — функция дожидается, не падает."""
+        calls = {"n": 0}
+
+        def flaky(_server):
+            calls["n"] += 1
+            return calls["n"] >= 3
+
+        with (
+            patch.object(wk, "_check_kafka", side_effect=flaky),
+            patch.object(wk, "_RETRY_INITIAL_DELAY", 0.0),
+            patch.object(wk, "_RETRY_MAX_DELAY", 0.0),
+        ):
+            await wk.wait_for_kafka("kafka:9092", timeout=5)
+        assert calls["n"] == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_on_timeout(self):
+        """Зависимость не поднялась в бюджет → RuntimeError (вызывающий перезапустит)."""
+        with (
+            patch.object(wk, "_check_kafka", return_value=False),
+            patch.object(wk, "_RETRY_INITIAL_DELAY", 0.0),
+            patch.object(wk, "_RETRY_MAX_DELAY", 0.0),
+            pytest.raises(RuntimeError),
+        ):
+            await wk.wait_for_kafka("kafka:9092", timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_stack_waits_for_both(self):
+        """Stack-хелпер ждёт и брокер, и schema registry."""
+        with (
+            patch.object(wk, "_check_kafka", return_value=True) as ck,
+            patch.object(wk, "_check_schema_registry", return_value=True) as cs,
+        ):
+            await wk.wait_for_kafka_stack("kafka:9092", "http://sr:8081", timeout=5)
+        ck.assert_called_once()
+        cs.assert_called_once()


### PR DESCRIPTION
## Проблема

После ежедневного ребута минипк по cron бот работал «наполовину»: Telegram-команды отвечают, а публикации/прогресс/результаты (FTP, WordPress, Boosty) — нет.

**Корень:** Docker поднимает контейнеры по `restart: always` **без** соблюдения `depends_on` (это правило уровня `docker compose up`, а не рантайма демона). Бот и publisher'ы стартуют раньше Kafka/Schema Registry, ловят ошибки в окне прогрева и остаются в сломанном состоянии; result-события теряются.

## Решение — три слоя защиты

**1. In-process readiness-гейты** (`app/shared/kafka/`)
- `wait_for_kafka.py` переписан на `confluent_kafka` + stdlib `urllib` (теперь импортируется во всех образах; старый вариант на `aiokafka` сломал бы Boosty/WordPress).
- Consumer ждёт Kafka+SR перед `subscribe`, producer — перед первой публикацией. Порядок старта перестаёт иметь значение, события не теряются.
- Backoff-паузы в error-ветках consumer'а — нет tight-loop.

**2. Супервайзер result-consumer'ов** (`app/bot/main.py`)
- Любой выход/падение/таймаут readiness → перезапуск. Бот больше не «полуживой».

**3. Оркестрация на хосте** (`deploy/podboxbot.service`)
- systemd-юнит: orchestrated `up -d` на загрузке, graceful `stop` на ребуте.
- `stop_grace_period: 60s` для Kafka в обоих compose-файлах → нет коррупции `kafka_data` при жёстком ребуте.

Слои 1–2 работают сами; слой 3 рекомендуется на проде (требует одноразовой установки юнита — инструкция в шапке файла).

## Тесты
- Новый `tests/unit/kafka/test_wait_for_kafka.py` (ready/retry/timeout/stack).
- `test_producer.py` — мок readiness как инфра-зависимости.
- Прогон затронутых областей: 57 passed, ruff clean.

## Ручной шаг на проде
Поправить `WorkingDirectory` в `deploy/podboxbot.service`, скопировать в `/etc/systemd/system/`, `systemctl daemon-reload && systemctl enable --now podboxbot`.
