### PR TITLE
fix(compose): add restart policy to schema-registry so it recovers after reboot

### DIFF
--- a/docker-compose.tun2socks.yml
+++ b/docker-compose.tun2socks.yml
@@ -163,6 +163,12 @@ services:
   schema-registry:
     image: confluentinc/cp-schema-registry:7.5.0
     container_name: podboxbot_schema-registry
+    # Без restart-политики SR при ребуте (где depends_on не соблюдается)
+    # стартует раньше Kafka, не дожидается брокера и САМ выключается —
+    # и больше не поднимается. Kafka позже становится healthy, а SR уже
+    # мёртв → бот жив, но публикации не работают. restart: always заставляет
+    # Docker перезапускать SR, пока Kafka не станет доступна.
+    restart: always
     depends_on:
       kafka:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,12 @@ services:
   schema-registry:
     image: confluentinc/cp-schema-registry:7.5.0
     container_name: podboxbot_schema-registry
+    # Без restart-политики SR при ребуте (где depends_on не соблюдается)
+    # стартует раньше Kafka, не дожидается брокера и САМ выключается —
+    # и больше не поднимается. Kafka позже становится healthy, а SR уже
+    # мёртв → бот жив, но публикации не работают. restart: always заставляет
+    # Docker перезапускать SR, пока Kafka не станет доступна.
+    restart: always
     depends_on:
       kafka:
         condition: service_healthy


### PR DESCRIPTION
## Корень проблемы (вскрыт readiness-гейтами из #25)

На проде после ребута `schema-registry` оказывался **мёртвым**, а бот — «полуживым» (Telegram отвечает, публикации нет).

Логи SR показали: контейнер стартует раньше Kafka (при ребуте `depends_on` не соблюдается), не может достучаться до брокера (`Connection to node 1 (kafka:9092) could not be established`), ретраит, затем **сам завершает работу** (`Shutting down schema registry`). После этого Kafka становится healthy, но SR уже выключен.

**Причина невозврата:** у `schema-registry` в обоих compose-файлах **отсутствовала `restart`-политика** (единственный долгоживущий сервис без неё). Docker его не перезапускал → SR оставался мёртвым до ручного вмешательства.

## Фикс

`restart: always` для `schema-registry` в `docker-compose.yml` и `docker-compose.tun2socks.yml`. Теперь Docker перезапускает SR, пока Kafka не станет доступна, после чего он стабильно поднимается.

Вместе с readiness-гейтами из #25 (бот/publisher'ы ждут SR) и systemd-оркестрацией стек полностью самовосстанавливается после ребута.

## Проверка
- `docker compose config` валиден (оба файла парсятся, 19/20 сервисов, `SR restart=always`).
- На проде: `docker compose up -d schema-registry` поднимает SR, зависшие загрузки проходят.
