### PR TITLE
chore: ignore ruff cache and nested per-service files dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # Files
+**/.ruff_cache/
 test.py
 test2.py
 database.sqlite
-files/*.mp3
-files/*.pkl
-files/*.json
+**/files/*.mp3
+**/files/*.pkl
+**/files/*.json
 boosty_auth.json
 **/boosty_auth.json
 


### PR DESCRIPTION
Two small `.gitignore` adjustments:

- Add `**/.ruff_cache/` so ruff's cache stays out of the tree no matter which service dir it runs in.
- Broaden `files/*.{mp3,pkl,json}` to `**/files/*.{mp3,pkl,json}` — each publisher has its own `files/` dir now, and the old top-level-only globs let those slip through.